### PR TITLE
Update Method Type POST to PUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ curl -X GET \
 ### Update a product
 
 ```bash
-curl -X POST \
+curl -X PUT \
   'http://localhost:8765/api/products/{product-id}' \
   -H 'Content-Type: application/json' \
   -d '{


### PR DESCRIPTION
Error when use method POST
{
  "timestamp" : 1535669078704,
  "status" : 405,
  "error" : "Method Not Allowed",
  "message" : "HTTP 405 Method Not Allowed",
  "path" : "/api/products/5b8870e8f6ce10194847c7a3"
}